### PR TITLE
Fix spelling for "purpose" at the tutorial page

### DIFF
--- a/assets/tutorial/g-scout-01.js
+++ b/assets/tutorial/g-scout-01.js
@@ -102,7 +102,7 @@ module.exports = () => {
               </xml>`
     },
 
-    label: 'Scout - Or... Walking Around Without Puropse',
+    label: 'Scout - Or... Walking Around Without Purpose',
 
     goals: [
       {


### PR DESCRIPTION
Sorry for the small commit, just fixed the spelling of "purpose" in the label.